### PR TITLE
Fully implement kernel increment of date and time

### DIFF
--- a/kernel/kernel.cpp
+++ b/kernel/kernel.cpp
@@ -226,8 +226,44 @@ void Kernel::increment_tod()
 			_tod.hours++;
 			if (_tod.hours > 23) {
 				_tod.hours = 0;
-				
-				// oh no!
+				_tod.day++;
+				if (_tod.day > 28)
+				{
+					switch (_tod.month) {
+						case 1:
+						case 3:
+						case 5:
+						case 7:
+						case 8:
+						case 10:
+						case 12:
+							_tod.day %= 32;
+							break;
+						case 2: {
+							bool is_leap_year = (_tod.year % 4 == 0) && (!(_tod.year % 100 == 0) || (_tod.year % 400 == 0));
+							_tod.day %= is_leap_year ? 30 : 29;
+							break;
+						}
+						case 4:
+						case 6:
+						case 9:
+						case 11:
+							_tod.day %= 31;
+							break;
+					}
+
+					// Update month if days were reset
+					if (_tod.day == 0) {
+						_tod.day++;
+						_tod.month++;
+
+						if (_tod.month > 12)
+						{
+							_tod.month = 1;
+							_tod.year++;
+						}
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR looks to fully implement the `increment_tod()` method inside `kernel.cpp` such that it can handle new days, months and years. In the old kernel, the date would be fixed with the kernel only updating the times. This had the effect of the time cycling from 23:59 to 00:00 without the date incrementing (e.g `31/12/1970 23:59:59` --> `31/12/1970 00:00:00`). 

Now the date, month and year is updated as necessary. Testing was done on these cases:
- [x] New day: `01/01/1970` => `02/01/1970`
- [x] New month (31 days): `31/01/1970` => `01/02/1970`
- [x] Feb common year: `28/02/1970` => `01/03/1970`
- [x] Feb leap year (leap day):`28/02/1972` => `29/02/1972`
- [x] Feb leap year (new month): `29/02/1972` => `01/03/1972`
- [x] New month (30 days): `30/06/1972` => `01/07/1972`
- [x] New day: `30/12/1972` => `31/12/1972`
- [x] New year: `31/12/1972` => `01/01/1973`