### PR TITLE
Reserve pages for multiboot information structure

### DIFF
--- a/mm/page-allocator.cpp
+++ b/mm/page-allocator.cpp
@@ -8,6 +8,7 @@
  * 
  * Tom Spink <tspink@inf.ed.ac.uk>
  */
+#include <arch/x86/multiboot.h>
 #include <infos/mm/page-allocator.h>
 #include <infos/mm/mm.h>
 #include <infos/util/string.h>
@@ -108,6 +109,10 @@ bool PageAllocator::init()
 
 	// Reserve initial page table pages
 	nr_free_pages -= mark_page_range(PageDescriptorType::ALLOCATED, 1, 6);
+
+	// Reseve multiboot_info_structure data
+	pfn_t multiboot_info_start_pfn = pa_to_pfn((phys_addr_t)kva_to_pa((virt_addr_t)arch::x86::multiboot_info_structure));
+	nr_free_pages -= mark_page_range(PageDescriptorType::RESERVED, multiboot_info_start_pfn, 1);
 
 	// Now, reserve the kernel's pages
 


### PR DESCRIPTION
## Description

This is the work around I'm using to address issue #4 where `multiboot_info_structure` is zeroed out as it is allocated to the kernel page table.

The PR reserves the page where the `multiboot_info_structure` resides in.

## Test

Attach GDB to the running kernel and inspect address `0xffffffff80010000` with `x/32xg 0xffffffff80010000`.
It should contain information from multiboot now.