### PR TITLE
Dynamic memory from SchedulerAlgo constructor

### DIFF
--- a/include/infos/kernel/sched.h
+++ b/include/infos/kernel/sched.h
@@ -29,7 +29,7 @@ namespace infos
 			virtual const char *name() const = 0;
 			virtual SchedulingEntity *pick_next_entity();
 
-            virtual void init();
+            virtual void init() = 0;
 			virtual void add_to_runqueue(SchedulingEntity& entity) = 0;
 			virtual void remove_from_runqueue(SchedulingEntity& entity) = 0;
 		};

--- a/kernel/sched.cpp
+++ b/kernel/sched.cpp
@@ -66,6 +66,7 @@ bool Scheduler::init()
 
 	// Install the discovered algorithm.
 	_algorithm = algo;
+    _algorithm->init();
 
 	// Set the idle entity to be runnable, and forcibly activate it.  This is so that
 	// when interrupts are enabled, the idle thread becomes the context that is saved and restored.


### PR DESCRIPTION
1) SchedulingAlgorithm:init() should be called from the Scheduler::init() as someone might want to initialize the schedulerAlgorithm class before it can be able to schedule entities.
2) SchedulingAlgorithm:init() should be abstract.

@kimbethstonehouse what do you think?