### PR TITLE
Add serial console support, and replace CGA terminal escaping with ANSI

### DIFF
--- a/arch/x86/devices.cpp
+++ b/arch/x86/devices.cpp
@@ -132,7 +132,7 @@ bool infos::arch::x86::console_init()
 		return false;
 
 	// Create a terminal that will be associated with the virtual console.
-	Terminal *tty0 = new Terminal();
+	Terminal *tty0 = new ConsoleTerminal();
 	if (!sys.device_manager().register_device(*tty0))
 		return false;
 
@@ -141,7 +141,7 @@ bool infos::arch::x86::console_init()
 		return false;
 
 	// Create another terminal for a second virtual console.
-	if (!sys.device_manager().register_device(*new Terminal()))
+	if (!sys.device_manager().register_device(*new ConsoleTerminal()))
 		return false;
 
 	// Create and register two virtual console devices.
@@ -179,8 +179,8 @@ bool infos::arch::x86::activate_console()
 	if (!sys.device_manager().try_get_device_by_name("tty1", tty1)) return false;
 
 	// Attach the terminals to the virtual consoles.
-	vc0->attach_terminal(tty0);
-	vc1->attach_terminal(tty1);
+	vc0->attach_terminal((ConsoleTerminal*) tty0);
+	vc1->attach_terminal((ConsoleTerminal*) tty1);
 
 	// Initialise the physical console
 	kbd0->attach_sink(*pc0);

--- a/arch/x86/start.cpp
+++ b/arch/x86/start.cpp
@@ -29,7 +29,7 @@ using namespace infos::util;
 //static EarlyScreen early_screen;
 
 // Create a QEMU stream for the syslog.
-static QEMUStream qemu_stream;
+QEMUStream infos::arch::x86::qemu_stream;
 ComponentLog infos::arch::x86::x86_log(syslog, "x86");
 
 // Reference to the value of EBX at multiboot entry.

--- a/arch/x86/uart.cpp
+++ b/arch/x86/uart.cpp
@@ -38,13 +38,14 @@ int UART::read(void* buffer, size_t size)
 int UART::write(const void* buffer, size_t size)
 {
 	for (unsigned int i = 0; i < size; i++) {
-		syslog.message(LogLevel::INFO, "UART putting a character: ");
 		char c = ((char *)buffer)[i];
+#if 0
+		syslog.message(LogLevel::INFO, "UART putting a character: ");
 		char cs[] = { c, 0 };
 		if (c >= 32 && c < 128) syslog.message(LogLevel::INFO, cs);
 		else if (c < 32) syslog.message(LogLevel::INFO, "(control code)");
 		else syslog.message(LogLevel::INFO, "(high byte)");
-
+#endif
 		/* HACK: this translation doesn't belong in the UART code,
 		 * but in a 'serial console' translation layer or possibly
 		 * just in SerialTerminal. */

--- a/arch/x86/uart.cpp
+++ b/arch/x86/uart.cpp
@@ -1,0 +1,170 @@
+/* SPDX-License-Identifier: MIT */
+
+/*
+ * arch/x86/uart.cpp
+ *
+ * by Stephen Kell <srk31@srcf.ucam.org>
+ * borrowing heavily from MIT's xv6 uart.c code.
+ */
+#include <arch/x86/pio.h>
+#include <infos/kernel/device-manager.h>
+#include <infos/kernel/irq.h>
+#include <infos/kernel/kernel.h>
+#include <infos/kernel/log.h>
+#include <infos/drivers/irq/ioapic.h>
+#include <infos/drivers/irq/lapic.h>
+#include <arch/x86/uart.h>
+#include <infos/drivers/terminal/terminal.h>
+#include <arch/x86/pio.h>
+
+using namespace infos::kernel;
+using namespace infos::drivers;
+using namespace infos::drivers::irq;
+using namespace infos::arch::x86;
+
+const uint16_t UART::COM1 = 0x3f8;
+const int UART::IRQ_COM1 = 4;
+
+const DeviceClass UART::UARTDeviceClass(Device::RootDeviceClass, "uart");
+
+int UART::read(void* buffer, size_t size)
+{
+	for (unsigned int i = 0; i < size; i++) {
+		((char *)buffer)[i] = getc();
+	}
+	return size;
+}
+
+int UART::write(const void* buffer, size_t size)
+{
+	for (unsigned int i = 0; i < size; i++) {
+		syslog.message(LogLevel::INFO, "UART putting a character: ");
+		char c = ((char *)buffer)[i];
+		char cs[] = { c, 0 };
+		if (c >= 32 && c < 128) syslog.message(LogLevel::INFO, cs);
+		else if (c < 32) syslog.message(LogLevel::INFO, "(control code)");
+		else syslog.message(LogLevel::INFO, "(high byte)");
+
+		/* HACK: this translation doesn't belong in the UART code,
+		 * but in a 'serial console' translation layer or possibly
+		 * just in SerialTerminal. */
+		if (c == '\n') { putc('\r'); putc('\n'); }
+		else putc(c);
+	}
+	return size;
+}
+
+UART::UART() : _attached_terminal(nullptr)
+{
+	syslog.message(LogLevel::INFO, "created a UART");
+	//init();
+	assert(present);
+	// Announce that we're here.
+#define write_string(s) write((s), sizeof (s) - 1)
+	write_string("Hello from the InfOS serial console\nLots and lots of very"
+	"very long text to debug the information on possible error conditions that may"
+	" exist within the UART, based on the data that has been received. Keep in mind"
+	" that this is a \"read only\" register, and any data written to this register"
+	" is likely to be ignored or worse, cause different behavior in the UART."
+	" There are several uses for this information, and some information will"
+	" be given below on how it can be useful for diagnosing problems with your"
+	" serial data connection: "
+	); // I get hex 1bf + ten  bytes of 02 82 after this message, regardless...
+}
+
+bool UART::init(kernel::DeviceManager& dm)
+{
+	syslog.message(LogLevel::INFO, "initing a UART");
+	__outb(COM1 + FCR, 0);           // turn off the on-chip FIFO (we want a plain old 8250)
+	__outb(COM1 + LCR, 0x80);        // unlock divisor
+	__outb(COM1 + DLL, 115200/9600); // divide the clock by 12 to get 9600 baud
+	__outb(COM1 + DLH, 0);           // high bit of 12 is 0
+	__outb(COM1 + LCR, 0x03);        // lock divisor and set 8 data bits, 1 stop bit, no parity
+	__outb(COM1 + MCR, 0);           // clear the modem control register
+	__outb(COM1 + IER, 0x01);        // enable receive interrupts.
+
+	// If status is 0xFF, no serial port.
+	if (__inb(COM1 + LSR) == 0xFF) { this->present = false; return false; }
+	this->present = true;
+
+	// acknowledge any pre-existing interrupt and 'consume' data to re-enable.
+	__inb(COM1 + IIR);
+	__inb(COM1 + RBR);
+
+	// Find the LAPIC.
+	LAPIC *lapic;
+	if (!dm.try_get_device_by_class(LAPIC::LAPICDeviceClass, lapic)) {
+		return false;
+	}
+
+	// Find the IOAPIC.
+	IOAPIC *ioapic;
+	if (!dm.try_get_device_by_class(IOAPIC::IOAPICDeviceClass, ioapic)) {
+		return false;
+	}
+
+	// Hook-up IRQ 4 on the IOAPIC to the IRQ handler object, and register
+	// the IRQ callback function.
+	_irq = ioapic->request_physical_irq(lapic, IRQ_COM1);
+	_irq->attach(UART::irq_handler, this);
+
+	// success
+	return true;
+}
+
+void
+UART::putc(int c)
+{
+	if (!present) return;
+	// Test for THR empty (=> ready to send), but wait at most 1280 us
+	int i;
+	uint8_t lsr;
+	for (i = 0; i < 128 && !((lsr = __inb(COM1 + LSR)) & 0x20); i++) sys.spin_delay(util::Microseconds(10));
+	if (i == 128) syslog.message(LogLevel::WARNING, "outputting to a UART with non-empty THR");
+	if (lsr & /* break interrupt, framing, parity, overrun error? */ 0x1e)
+	{
+		syslog.message(LogLevel::WARNING, "error on UART putc, but proceeding");
+		// continue
+	}
+	__outb(COM1 + THR, c);
+}
+
+int UART::getc()
+{
+	if (!present) return -1;
+	uint8_t lsr = __inb(COM1 + LSR);
+	if (!(lsr & /* data ready? */ 0x1))
+	{
+		syslog.message(LogLevel::WARNING, "getc from a UART with no data ready");
+		return -1; // not ready
+	}
+	if (lsr & /* framing error? */ 0x1<<3)
+	{
+		syslog.message(LogLevel::WARNING, "framing error on UART getc, but proceeding");
+		// continue
+	}
+	return __inb(COM1 + RBR);
+}
+
+void UART::irq_handler(const kernel::IRQ *irq, void *priv)
+{
+// xv6 calls uartintr from trap()
+// which is called from 'alltraps' in trapasm.S
+// which is called with args (trapno, 0) from a trampoline in vectors.S (one for each of 256 trapnos)
+// which also defines the 256-entry vector table, each pointing to its trampoline
+
+	/* This asks the console subsystem to buffer our pending data if there is any. */
+	/* XXX */ // consoleintr(uartgetc);
+
+	UART *uart = (UART *)priv;
+	int c = uart->getc();
+#if 1 /* This is just for testing */
+	if (c != -1) {
+		syslog.message(LogLevel::INFO, "UART interrupt yielded a character"/*, (char) c*/);
+	} else {
+		syslog.message(LogLevel::INFO, "UART interrupt yielded -1");
+	}
+#endif
+	// TODO: buffer this as pending data, something like this
+	// if (uart->_attached_terminal) uart->_attached_terminal->buffer_raw_character(c);
+}

--- a/arch/x86/uart.cpp
+++ b/arch/x86/uart.cpp
@@ -158,13 +158,13 @@ void UART::irq_handler(const kernel::IRQ *irq, void *priv)
 
 	UART *uart = (UART *)priv;
 	int c = uart->getc();
-#if 1 /* This is just for testing */
+#if 0 /* This is just for testing */
 	if (c != -1) {
 		syslog.message(LogLevel::INFO, "UART interrupt yielded a character"/*, (char) c*/);
 	} else {
 		syslog.message(LogLevel::INFO, "UART interrupt yielded -1");
 	}
 #endif
-	// TODO: buffer this as pending data, something like this
-	// if (uart->_attached_terminal) uart->_attached_terminal->buffer_raw_character(c);
+	// buffer this as pending data
+	if (uart->_attached_terminal) uart->_attached_terminal->buffer_raw_character(c);
 }

--- a/drivers/ata/ata-controller.cpp
+++ b/drivers/ata/ata-controller.cpp
@@ -115,7 +115,7 @@ uint8_t ATAController::ata_read(int channel, int reg)
 	} else if (reg < 0x0C) {
 		result = __inb(channels[channel].base + reg - 0x06);
 	} else if (reg < 0x0E) {
-		result = __inb(channels[channel].ctrl + reg - 0x0A);
+		result = __inb(channels[channel].ctrl + reg - 0x0C);
 	} else if (reg < 0x16) {
 		result = __inb(channels[channel].bmide + reg - 0x0E);
 	}
@@ -138,7 +138,7 @@ void ATAController::ata_read_buffer(int channel, int reg, void* buffer, size_t s
 	} else if (reg < 0x0C) {
 		__insl(channels[channel].base + reg - 0x06, (uintptr_t)buffer, size >> 2);
 	} else if (reg < 0x0E) {
-		__insl(channels[channel].ctrl + reg - 0x0A, (uintptr_t)buffer, size >> 2);
+		__insl(channels[channel].ctrl + reg - 0x0C, (uintptr_t)buffer, size >> 2);
 	} else if (reg < 0x16) {
 		__insl(channels[channel].bmide + reg - 0x0E, (uintptr_t)buffer, size >> 2);
 	}
@@ -159,7 +159,7 @@ void ATAController::ata_write(int channel, int reg, uint8_t data)
 	} else if (reg < 0x0C) {
 		__outb(channels[channel].base + reg - 0x06, data);
 	} else if (reg < 0x0E) {
-		__outb(channels[channel].ctrl + reg - 0x0A, data);
+		__outb(channels[channel].ctrl + reg - 0x0C, data);
 	} else if (reg < 0x16) {
 		__outb(channels[channel].bmide + reg - 0x0E, data);
 	}

--- a/drivers/console/virtual-console.cpp
+++ b/drivers/console/virtual-console.cpp
@@ -37,7 +37,7 @@ VirtualConsole::~VirtualConsole()
 	delete _buffer;
 }
 
-void VirtualConsole::attach_terminal(terminal::Terminal *terminal)
+void VirtualConsole::attach_terminal(terminal::ConsoleTerminal *terminal)
 {
 	_terminal = terminal;
 	_terminal->attach_output(*this);

--- a/drivers/terminal/terminal.cpp
+++ b/drivers/terminal/terminal.cpp
@@ -24,14 +24,24 @@ const DeviceClass Terminal::TerminalDeviceClass(Device::RootDeviceClass, "tty");
 
 Terminal::Terminal()
 	: _read_buffer_head(0),
-		_read_buffer_tail(0),
-		_attached_virt_console(NULL),
+		_read_buffer_tail(0)
+{
+
+}
+
+ConsoleTerminal::ConsoleTerminal()
+	: 	_attached_virt_console(NULL),
 		_attached_phys_console(NULL)
 {
 
 }
 
 Terminal::~Terminal()
+{
+
+}
+
+ConsoleTerminal::~ConsoleTerminal()
 {
 
 }
@@ -65,7 +75,7 @@ int Terminal::read(void* raw_buffer, size_t size)
 	return n;
 }
 
-int Terminal::write(const void* buffer, size_t size)
+int ConsoleTerminal::write(const void* buffer, size_t size)
 {
 	if (_attached_virt_console) {
 		return _attached_virt_console->write(buffer, size);

--- a/drivers/terminal/terminal.cpp
+++ b/drivers/terminal/terminal.cpp
@@ -36,12 +36,22 @@ ConsoleTerminal::ConsoleTerminal()
 
 }
 
+SerialTerminal::SerialTerminal()
+{
+
+}
+
 Terminal::~Terminal()
 {
 
 }
 
 ConsoleTerminal::~ConsoleTerminal()
+{
+
+}
+
+SerialTerminal::~SerialTerminal()
 {
 
 }
@@ -73,6 +83,26 @@ int Terminal::read(void* raw_buffer, size_t size)
 	}
 
 	return n;
+}
+
+int SerialTerminal::write(const void* buffer, size_t size)
+{
+	if (_attached_uart) {
+		return _attached_uart->write(buffer, size);
+	} else {
+		return 0;
+	}
+}
+void SerialTerminal::buffer_raw_character(uint8_t c)
+{
+	switch (c)
+	{
+		/* For a physical keyboard on the VGA console keyboard, the key 'Enter'
+		 * generates '\n'. So translate the raw serial protocol to do the same. */
+		case '\r': append_to_read_buffer('\n'); break;
+		default:
+			append_to_read_buffer(c); break;
+	}
 }
 
 int ConsoleTerminal::write(const void* buffer, size_t size)

--- a/include/arch/interface.h
+++ b/include/arch/interface.h
@@ -1,1 +1,0 @@
-/disk/scratch/spink/infos/include/arch/x86/interface.h

--- a/include/arch/x86/qemu-stream.h
+++ b/include/arch/x86/qemu-stream.h
@@ -16,6 +16,7 @@ namespace infos
 				int read(void* buffer, size_t size) override;
 				int write(const void* buffer, size_t size) override;
 			};
+			extern QEMUStream qemu_stream;
 		}
 	}
 }

--- a/include/arch/x86/uart.h
+++ b/include/arch/x86/uart.h
@@ -12,9 +12,10 @@ namespace infos
 	namespace drivers {
 		namespace terminal {
 			class Terminal;
+			class SerialTerminal;
 		}
 	}
-	using drivers::terminal::Terminal;
+	using drivers::terminal::SerialTerminal;
 	namespace arch
 	{
 		namespace x86
@@ -48,11 +49,11 @@ namespace infos
 				void putc(int c);
 				int getc();
 				static void irq_handler(const kernel::IRQ *irq, void *priv);
-				void attach_terminal(Terminal& term) { _attached_terminal = &term; }
+				void attach_terminal(SerialTerminal& term) { _attached_terminal = &term; }
 				friend class SerialTerminal; // a bit nasty
 			private:
 				kernel::IRQ *_irq;
-				Terminal *_attached_terminal;
+				SerialTerminal *_attached_terminal;
 			};
 		}
 	}

--- a/include/arch/x86/uart.h
+++ b/include/arch/x86/uart.h
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: MIT */
+
+#pragma once
+
+#include <infos/io/stream.h>
+#include <infos/kernel/device-manager.h>
+#include <infos/kernel/irq.h>
+#include <arch/x86/uart.h>
+#include <infos/drivers/device.h>
+namespace infos
+{
+	namespace drivers {
+		namespace terminal {
+			class Terminal;
+		}
+	}
+	using drivers::terminal::Terminal;
+	namespace arch
+	{
+		namespace x86
+		{
+			class UART : public infos::drivers::Device
+			{
+				bool present;
+			public:
+				static const infos::drivers::DeviceClass UARTDeviceClass;
+				UART();
+				bool init(kernel::DeviceManager& dm) override;
+				static const uint16_t COM1;
+				static const int IRQ_COM1;
+				enum UartRegister
+				{
+					/* W */  THR = 0,  /* Transmitter Holding Buffer -- only when DLAB == 0 */
+					/* R */  RBR = 0,  /* Receiver Buffer -- only when DLAB == 0 */
+					/* RW */ DLL = 0, /* Divisor Latch Low Byte -- only when DLAB == 1*/
+					/* RW */ IER = 1, /* Interrupt Enable -- only when DLAB == 0 */
+					/* RW */ DLH = 1, /* Divisor Latch High Byte -- only when DLAB == 1*/
+					/* R */  IIR = 2,  /* Interrupt Identification */
+					/* W */  FCR = 2,  /* FIFO Control */
+					/* RW */ LCR = 3, /* Line Control */
+					/* RW */ MCR = 4, /* Modem Control */
+					/* R */  LSR = 5,  /* Line Status */
+					/* R */  MSR = 6,  /* Modem Status */
+					/* RW */ SR = 7,  /* Scratch */
+				};
+				int read(void* buffer, size_t size);
+				int write(const void* buffer, size_t size);
+				void putc(int c);
+				int getc();
+				static void irq_handler(const kernel::IRQ *irq, void *priv);
+				void attach_terminal(Terminal& term) { _attached_terminal = &term; }
+				friend class SerialTerminal; // a bit nasty
+			private:
+				kernel::IRQ *_irq;
+				Terminal *_attached_terminal;
+			};
+		}
+	}
+}
+

--- a/include/infos/drivers/console/virtual-console.h
+++ b/include/infos/drivers/console/virtual-console.h
@@ -90,10 +90,16 @@ namespace infos
 
 				KeyboardModifiers _current_mod_mask;
 
+				uint8_t apply_ansi_specifier(int code);
+				void parse_escape_buffer();
+
 				constexpr static int _width = 80;
 				constexpr static int _height = 25;
 
 				uint16_t _current_pos;
+				uint8_t _escape_nchars;
+				uint8_t _attr_byte;
+				uint8_t _escape_buffer[16];
 
 				terminal::Terminal *_terminal;
 				uint16_t *_buffer;

--- a/include/infos/drivers/console/virtual-console.h
+++ b/include/infos/drivers/console/virtual-console.h
@@ -19,7 +19,7 @@ namespace infos
 	{
 		namespace terminal
 		{
-			class Terminal;
+			class ConsoleTerminal;
 		}
 
 		namespace console
@@ -57,7 +57,7 @@ namespace infos
 				uint16_t *get_buffer() const { return _buffer; }
 				uint16_t get_buffer_position() const { return _current_pos; }
 
-				void attach_terminal(terminal::Terminal *terminal);
+				void attach_terminal(terminal::ConsoleTerminal *terminal);
 
 				bool supports_colour() const override { return true; }
 
@@ -101,7 +101,7 @@ namespace infos
 				uint8_t _attr_byte;
 				uint8_t _escape_buffer[16];
 
-				terminal::Terminal *_terminal;
+				terminal::ConsoleTerminal *_terminal;
 				uint16_t *_buffer;
 				UpdateCallbackFn _ucb;
 

--- a/include/infos/drivers/terminal/terminal.h
+++ b/include/infos/drivers/terminal/terminal.h
@@ -35,15 +35,10 @@ namespace infos {
 				
 				const DeviceClass& device_class() const override { return TerminalDeviceClass; }
 				
-				void attach_output(console::VirtualConsole& console) { _attached_virt_console = &console; }
-				void attach_input(console::PhysicalConsole& console) { _attached_phys_console = &console; }
-				
 				void append_to_read_buffer(uint8_t c);
 				
 				int read(void* buffer, size_t size) override;
-				int write(const void* buffer, size_t size) override;
-				
-				bool supports_colour() const { return true; }
+				virtual bool supports_colour() const = 0;
 				
 				fs::File* open_as_file() override;
 				
@@ -51,7 +46,21 @@ namespace infos {
 				uint8_t _read_buffer[64];
 				uint8_t _read_buffer_head, _read_buffer_tail;
 				util::Event _read_buffer_event;
+			};
+			class ConsoleTerminal : public Terminal
+			{
+			public:
+				ConsoleTerminal();
+				virtual ~ConsoleTerminal();
 				
+				void attach_output(console::VirtualConsole& console) { _attached_virt_console = &console; }
+				void attach_input(console::PhysicalConsole& console) { _attached_phys_console = &console; }
+
+				int write(const void* buffer, size_t size) override;
+
+				bool supports_colour() const { return true; }
+
+			private:
 				console::VirtualConsole *_attached_virt_console;
 				console::PhysicalConsole *_attached_phys_console;
 			};

--- a/include/infos/drivers/terminal/terminal.h
+++ b/include/infos/drivers/terminal/terminal.h
@@ -12,6 +12,7 @@
 #include <infos/drivers/device.h>
 #include <infos/io/stream.h>
 #include <infos/util/event.h>
+#include <arch/x86/uart.h> /* HACK */
 
 namespace infos {
 	namespace fs {
@@ -63,6 +64,24 @@ namespace infos {
 			private:
 				console::VirtualConsole *_attached_virt_console;
 				console::PhysicalConsole *_attached_phys_console;
+			};
+			class SerialTerminal : public Terminal
+			{
+			public:
+				SerialTerminal();
+				virtual ~SerialTerminal();
+
+				/* FIXME: UART should not be in arch::x86 */
+				void attach_uart(arch::x86::UART& uart) { _attached_uart = &uart; }
+
+				int write(const void* buffer, size_t size) override;
+				/* Serial line protocols might require us to lightly cook the raw chars. */
+				void buffer_raw_character(uint8_t c);
+
+				bool supports_colour() const { return true; }
+
+			private:
+				arch::x86::UART *_attached_uart;
 			};
 		}
 	}


### PR DESCRIPTION
These patches add support for a serial console. The UART code is loosely based on that of MIT's xv6. It has allowed me at King's to run a coursework that is hosted on a single machine that the students use exclusively over SSH.

As well as adding the UART driver, the changes modify the terminal escaping, from the former ad-hoc scheme using the CGA attr byte to a subset of ANSI escape codes, enough to generate colour text on the students' terminal emulators.

All this is only tested on qemu, not real hardware, but it was used successfully by a class of nearly 400 students last spring.

There is a corresponding patchset for infos-user that I'll pull-request over there.